### PR TITLE
HD44780 LCD tweaks

### DIFF
--- a/devices/lcd_hd44780.hh
+++ b/devices/lcd_hd44780.hh
@@ -318,7 +318,7 @@ namespace yaal {
 
 
     // Supports PCF8574/PCF8574A based I2C expanders.
-    template<typename Backpack_type, uint8_t address, typename SDA = PortC4, typename SCL = PortC5>
+    template<typename Backpack_type, uint8_t address, typename SDA, typename SCL>
     class LCDInterface_I2C {
 
         SDA sda;

--- a/devices/lcd_hd44780.hh
+++ b/devices/lcd_hd44780.hh
@@ -107,7 +107,8 @@ namespace yaal {
         void entry_mode(IncDec id, bool shift) {
             interface.set_RS(false); // Select instruction register.
             interface.write(LCD_ENTRYMODESET |
-                           (id == INCREMENT ? LCD_ENTRYINCREMENT : LCD_ENTRYDECREMENT) |
+                           (id == INCREMENT ? LCD_ENTRYINCREMENT
+                                            : LCD_ENTRYDECREMENT) |
                            (shift ? LCD_ENTRYSHIFT : LCD_ENTRYNOSHIFT));
         }
 
@@ -233,7 +234,7 @@ namespace yaal {
 
                 // One.
                 pulse_enable();
-                _delay_us(4500); // >4.1 ms + >37 us is enough.
+                _delay_us(4300); // >4.1 ms + >37 us is enough.
 
                 // Two.
                 pulse_enable();
@@ -256,7 +257,7 @@ namespace yaal {
 
                 // One.
                 pulse_enable();
-                _delay_us(4500); // >4.1 ms + >37 us is enough.
+                _delay_us(4300); // >4.1 ms + >37 us is enough.
 
                 // Two.
                 pulse_enable();
@@ -286,8 +287,7 @@ namespace yaal {
         // Used for other read commands than reading the busy flag.
         uint8_t read() {
             wait_busy();
-            uint8_t ret = read_fast();
-            return ret;
+            return read_fast();
         }
 
         // An 8-bit read without a wait. Used for reading the busy flag.
@@ -343,7 +343,7 @@ namespace yaal {
                              // At 16 MHz, 1 instruction takes 62.5 ns.
             status.bits.enable = 1;
             commit_status();
-            _delay_us(1); // >450 ns is a sufficient pulse width.
+            _delay_us(.6); // >450 ns is a sufficient pulse width.
             status.bits.enable = 0;
             commit_status();
         }
@@ -410,7 +410,7 @@ namespace yaal {
 
             // One.
             pulse_enable();
-            _delay_us(4500); // >4.1 ms + >37 us is enough.
+            _delay_us(4300); // >4.1 ms + >37 us is enough.
 
             // Two.
             pulse_enable();

--- a/examples/adept_lcd_hd44780/main.cpp
+++ b/examples/adept_lcd_hd44780/main.cpp
@@ -82,14 +82,14 @@ void main() {
     // Borrowed the glyph from the CustomCharacter
     // Arduino sketch.
     uint8_t heart[8] = {
-            0b00000,
-            0b01010,
-            0b11111,
-            0b11111,
-            0b11111,
-            0b01110,
-            0b00100,
-            0b00000
+        0b00000,
+        0b01010,
+        0b11111,
+        0b11111,
+        0b11111,
+        0b01110,
+        0b00100,
+        0b00000
     };
 
     // Set the first glyph in CGRAM.

--- a/examples/adept_lcd_hd44780_i2c/main.cpp
+++ b/examples/adept_lcd_hd44780_i2c/main.cpp
@@ -86,14 +86,14 @@ void main() {
     // Borrowed the glyph from the CustomCharacter
     // Arduino sketch.
     uint8_t heart[8] = {
-            0b00000,
-            0b01010,
-            0b11111,
-            0b11111,
-            0b11111,
-            0b01110,
-            0b00100,
-            0b00000
+        0b00000,
+        0b01010,
+        0b11111,
+        0b11111,
+        0b11111,
+        0b01110,
+        0b00100,
+        0b00000
     };
 
     // Set the first glyph in CGRAM.

--- a/examples/adept_lcd_hd44780_i2c/main.cpp
+++ b/examples/adept_lcd_hd44780_i2c/main.cpp
@@ -17,7 +17,7 @@ uint16_t byte_to_hex(uint8_t byte) {
 // LcdBackPack<RS, RW, Enable, Data4, Data5, Data6, Data7, Backlight, Backlight_polarity>.
 // Typical I2C addresses are 0x20-0x27 and 0x38-0x3F.
 //typedef LCDInterface_I2C<LcdBackPack_Type2, 0x20> I2CInterface;
-typedef LCDInterface_I2C<LcdBackPack_Type1, 0x27> I2CInterface;
+typedef LCDInterface_I2C<LcdBackPack_Type1, 0x27, PortC4, PortC5> I2CInterface;
 typedef LiquidCrystalHD44780<I2CInterface, 2, false> LCD;
 
 void main() {


### PR DESCRIPTION
These are small changes to the HD44780 code to improve latencies and make it possible to build lcd_hd44780 based projects on boards with an MCU that does not have PortC4 and/or PortC5, such as the Arduino Leonardo (mega32u4).