### PR TITLE
lcd_hd44780: Fix #include with relative path

### DIFF
--- a/devices/lcd_hd44780.hh
+++ b/devices/lcd_hd44780.hh
@@ -4,7 +4,7 @@
 #ifdef __YAAL__
 
 #include <util/delay.h>
-#include "../../communication/i2c_hw.hh"
+#include "../communication/i2c_hw.hh"
 #include "lcd_backpack.hh"
 
 namespace yaal {


### PR DESCRIPTION
Just a small build fix for the lcd_hd44780 driver.